### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go test && go run --one=4353 --two=1283923"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-[![Build Status](https://travis-ci.com/circutrider21/Manageo.svg?branch=master)](https://travis-ci.com/circutrider21/Manageo)
+[![Build Status](https://travis-ci.com/circutrider21/Manageo.svg?branch=master)](https://travis-ci.com/circutrider21/Manageo)       
+[![Run on Repl.it](https://repl.it/badge/github/circutrider21/Manageo)](https://repl.it/github/circutrider21/Manageo)
 # Manageo


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@circutrider21/Manageo).